### PR TITLE
feat: add docker-compose configuration

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,33 @@
+version: '3.1'
+
+services:
+
+  csaladihazneked-hu-cms:
+    image: wordpress
+    restart: always
+    ports:
+      - 80:80
+    environment:
+      WORDPRESS_DB_HOST: db
+      WORDPRESS_DB_USER: csaladihazneked-hu
+      WORDPRESS_DB_PASSWORD: csaladihazneked-hu
+      WORDPRESS_DB_NAME: csaladihazneked-hu-wordpress
+    volumes:
+      - csaladihazneked-hu-cms:/var/www/html
+      - ./cms/uploads.ini:/usr/local/etc/php/conf.d/uploads.ini
+      - ./cms/wp-content:/var/www/html/wp-content/
+
+  db:
+    image: mysql:8.0
+    restart: always
+    environment:
+      MYSQL_DATABASE: csaladihazneked-hu-wordpress
+      MYSQL_USER: csaladihazneked-hu
+      MYSQL_PASSWORD: csaladihazneked-hu
+      MYSQL_RANDOM_ROOT_PASSWORD: '1'
+    volumes:
+      - db:/var/lib/mysql
+
+volumes:
+  csaladihazneked-hu-cms:
+  db:

--- a/www/Dockerfile
+++ b/www/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:18
+
+MAINTAINER kristofkekesi
+
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+EXPOSE 3000
+CMD npm run dev


### PR DESCRIPTION
The docker-compose configuration file has been added to set up the csaladihazneked-hu-cms and db services. The csaladihazneked-hu-cms service uses the wordpress image and is exposed on port 80. It is linked to the db service, which uses the mysql:8.0 image. The necessary environment variables and volumes are configured for both services.

Additionally, a Dockerfile has been added to set up the node:18 image for the application. The necessary dependencies are installed and the application is exposed on port 3000. The command "npm run dev" is executed to start the application.