### PR TITLE
feat: update page limit for similar blueprints to be configurable through environment variable

### DIFF
--- a/www/src/app/(production)/tervrajzok/[slug]/hasonloak/page.tsx
+++ b/www/src/app/(production)/tervrajzok/[slug]/hasonloak/page.tsx
@@ -27,7 +27,8 @@ export const metadata: Metadata = {
 export default async function Blueprints({params}: Params) {
 	const blueprint: Blueprint = ( await getBlueprints({ slug: params.slug }))[0];
 	const similarBlueprints: Array<Blueprint> =
-		await getSimilarBlueprints({ blueprint, limit: 18 });
+		await getSimilarBlueprints({ blueprint, limit: 
+			parseInt(process.env.WEBSITE_SIMILAR_BLUEPRINT_PAGE_LIMIT ?? "18") });
 
 	return (
 		<main className="flex flex-col just pt-3">


### PR DESCRIPTION
The `getSimilarBlueprints` function now accepts a `limit` parameter that is set to the value of `process.env.WEBSITE_SIMILAR_BLUEPRINT_PAGE_LIMIT` if it exists, otherwise it defaults to 18. This allows for easy configuration of the page limit for similar blueprints without modifying the code.