### PR TITLE
refactor: Remove unnecessary DEV_TRANSPARENT_IMAGES guard clauses and…

### DIFF
--- a/www/src/components/blueprint/BlueprintBig.tsx
+++ b/www/src/components/blueprint/BlueprintBig.tsx
@@ -32,14 +32,6 @@ type Params = {
  * @returns A component with many info about the blueprint given.
  */
 export default function BlueprintBig(params: Params) {
-	// Guard closes
-	const DEV_TRANSPARENT_IMAGES = process.env.NEXT_PUBLIC_DEV_TRANSPARENT_IMAGES;
-	if (DEV_TRANSPARENT_IMAGES === undefined) {
-		throw new Error(
-			"NEXT_PUBLIC_DEV_TRANSPARENT_IMAGES environmental variable is not provided."
-		);
-	}
-
 	return (
 		<Card className="flex rounded-t-3xl">
 			<div className="w-full md:w-2/3">

--- a/www/src/components/blueprint/BlueprintMedium.tsx
+++ b/www/src/components/blueprint/BlueprintMedium.tsx
@@ -32,14 +32,6 @@ type Params = {
  * @returns A component with some information about the `blueprint` provided.
  */
 export default async function BlueprintMedium({ blueprint, className }: Params) {
-	// Guard closes
-	const DEV_TRANSPARENT_IMAGES = process.env.NEXT_PUBLIC_DEV_TRANSPARENT_IMAGES;
-	if (DEV_TRANSPARENT_IMAGES === undefined) {
-		throw new Error(
-			"NEXT_PUBLIC_DEV_TRANSPARENT_IMAGES environmental variable is not provided."
-		);
-	}
-
 	return (
 		<Card
 			className={cn("group rounded-b-3xl bg-cover", className)}

--- a/www/src/components/blueprint/BlueprintSmall.tsx
+++ b/www/src/components/blueprint/BlueprintSmall.tsx
@@ -24,14 +24,6 @@ type Params = {
  * @returns Minimal information about a given `blueprint`.
  */
 export default function BlueprintSmall(params: Params) {
-	// Guard closes
-	const DEV_TRANSPARENT_IMAGES = process.env.NEXT_PUBLIC_DEV_TRANSPARENT_IMAGES;
-	if (DEV_TRANSPARENT_IMAGES === undefined) {
-		throw new Error(
-			"NEXT_PUBLIC_DEV_TRANSPARENT_IMAGES environmental variable is not provided."
-		);
-	}
-
 	return (
 		<Link href={`/tervrajzok/${params.blueprint.slug}`}>
 			<Card className={

--- a/www/src/components/general/Image.tsx
+++ b/www/src/components/general/Image.tsx
@@ -25,13 +25,9 @@ type customImageParams = Required<
 export default function CustomImage({
 	alt, src, className, imageClassName, ...params
 }: customImageParams) {
-	// Guard closes
-	const DEV_TRANSPARENT_IMAGES = process.env.NEXT_PUBLIC_DEV_TRANSPARENT_IMAGES;
-	if (DEV_TRANSPARENT_IMAGES === undefined) {
-		throw new Error(
-			"NEXT_PUBLIC_DEV_TRANSPARENT_IMAGES environmental variable is not provided."
-		);
-	}
+	const DEV_TRANSPARENT_IMAGES = 
+		process.env.NEXT_PUBLIC_DEV_TRANSPARENT_IMAGES ? 
+			process.env.NEXT_PUBLIC_DEV_TRANSPARENT_IMAGES : "false";
 
 	/**
 	 * Error handler to change the src parameter to the fallback image.

--- a/www/src/components/general/ImageRenderer.tsx
+++ b/www/src/components/general/ImageRenderer.tsx
@@ -13,13 +13,9 @@ import { isTrue } from "@/lib/utils";
  * @returns An image populated by the `params`.
  */
 export default function ImageRenderer(params: any) {
-    // Guard closes
-	const DEV_TRANSPARENT_IMAGES = process.env.NEXT_PUBLIC_DEV_TRANSPARENT_IMAGES;
-	if (DEV_TRANSPARENT_IMAGES === undefined) {
-		throw new Error(
-            "NEXT_PUBLIC_DEV_TRANSPARENT_IMAGES environmental variable is not provided."
-        );
-	}
+    const DEV_TRANSPARENT_IMAGES = 
+		process.env.NEXT_PUBLIC_DEV_TRANSPARENT_IMAGES ? 
+			process.env.NEXT_PUBLIC_DEV_TRANSPARENT_IMAGES : "false";
 
     // Note: must use span: "Invalid HTML may cause hydration mismatch such as div inside p.".
     return (

--- a/www/src/components/general/gallery/CustomGallery.tsx
+++ b/www/src/components/general/gallery/CustomGallery.tsx
@@ -2,8 +2,8 @@
 
 "use client";
 
-import { cn, isTrue } from "@/lib/utils";
 import React, { useEffect } from "react";
+import { cn } from "@/lib/utils";
 import CustomImage from "@/components/general/Image";
 import { Image as ImageType } from "@/types/Image";
 import PhotoAlbum from "react-photo-album";
@@ -44,16 +44,6 @@ export function onClick(params: any) {
 }
 
 function CustomImageRenderer(params: any) {
-    // Guard closes
-	const DEV_TRANSPARENT_IMAGES = process.env.NEXT_PUBLIC_DEV_TRANSPARENT_IMAGES;
-	if (DEV_TRANSPARENT_IMAGES === undefined) {
-		throw new Error(
-            "NEXT_PUBLIC_DEV_TRANSPARENT_IMAGES environmental variable is not provided."
-        );
-	}
-
-    const source = isTrue(DEV_TRANSPARENT_IMAGES) ? "/transparent.png" : params.photo.src;
-
     params.wrapperStyle["height"] = params.layout.height;
 
     return (
@@ -62,13 +52,13 @@ function CustomImageRenderer(params: any) {
                 <CustomImage
                     alt={ params.photo.alt }
                     title={ params.photo.title }
-                    src={ source }
+                    src={ params.photo.src }
                     loading="lazy"
                     sizes={ params.imageProps.sizes }
                     className="block w-full h-full"
                     imageClassName={cn("image", params.imageProps.className)}
 
-                    data-src={ source }
+                    data-src={ params.photo.src }
                     data-index={ params.layout.index }
                 />
             </div>


### PR DESCRIPTION
… simplify custom image rendering

Removed the DEV_TRANSPARENT_IMAGES guard clauses from CustomImageRenderer, ImageRenderer, BlueprintSmall, BlueprintMedium, and BlueprintBig components to simplify the code and improve readability. Also, simplified the source and data-src handling in CustomImageRenderer.